### PR TITLE
Fix: metadata created with project id referal in first 32 bytes

### DIFF
--- a/src/CroptopPublisher.sol
+++ b/src/CroptopPublisher.sol
@@ -247,9 +247,10 @@ contract CroptopPublisher {
                 dataToAdd: abi.encode(true, tierIdsToMint)
             });
 
-            // Store the referal id in the first 32 bytes of the metadata
+            // Store the referal id in the first 32 bytes of the metadata (push to stack for immutable in assembly)
+            uint256 _feeProjectId = FEE_PROJECT_ID;
             assembly {
-                mstore(add(mintMetadata, 32), fee)
+                mstore(add(mintMetadata, 32), _feeProjectId)
             }
         }
 

--- a/src/CroptopPublisher.sol
+++ b/src/CroptopPublisher.sol
@@ -248,9 +248,9 @@ contract CroptopPublisher {
             });
 
             // Store the referal id in the first 32 bytes of the metadata (push to stack for immutable in assembly)
-            uint256 _feeProjectId = FEE_PROJECT_ID;
+            uint256 feeProjectId = FEE_PROJECT_ID;
             assembly {
-                mstore(add(mintMetadata, 32), _feeProjectId)
+                mstore(add(mintMetadata, 32), feeProjectId)
             }
         }
 

--- a/src/CroptopPublisher.sol
+++ b/src/CroptopPublisher.sol
@@ -242,10 +242,14 @@ contract CroptopPublisher {
             // Create the metadata for the payment to specify the tier IDs that should be minted. We create manually the original metadata, following
             // the specifications from the JBMetadataResolver library.
             mintMetadata = JBMetadataResolver.addToMetadata({
-                originalMetadata: abi.encodePacked(bytes32(0), bytes32(abi.encodePacked(uint32(FEE_PROJECT_ID), uint8(2))), additionalPayMetadata),
+                originalMetadata: additionalPayMetadata,
                 idToAdd: bytes4(bytes20(metadata.dataHook)),
                 dataToAdd: abi.encode(true, tierIdsToMint)
             });
+
+            assembly {
+                mstore(add(mintMetadata, 32), fee)
+            }
         }
 
         {

--- a/src/CroptopPublisher.sol
+++ b/src/CroptopPublisher.sol
@@ -247,6 +247,7 @@ contract CroptopPublisher {
                 dataToAdd: abi.encode(true, tierIdsToMint)
             });
 
+            // Store the referal id in the first 32 bytes of the metadata
             assembly {
                 mstore(add(mintMetadata, 32), fee)
             }

--- a/src/CroptopPublisher.sol
+++ b/src/CroptopPublisher.sol
@@ -88,7 +88,7 @@ contract CroptopPublisher {
 
     /// @notice The divisor that describes the fee that should be taken.
     /// @dev This is equal to 100 divided by the fee percent.
-    uint256 constant public FEE_DIVISOR = 20;
+    uint256 public constant FEE_DIVISOR = 20;
 
     /// @notice The controller that directs the projects being posted to.
     IJBController public immutable CONTROLLER;
@@ -239,7 +239,8 @@ contract CroptopPublisher {
             // Add the new tiers.
             IJB721TiersHook(metadata.dataHook).adjustTiers(tiersToAdd, new uint256[](0));
 
-            // Create the metadata for the payment to specify the tier IDs that should be minted. We create manually the original metadata, following
+            // Create the metadata for the payment to specify the tier IDs that should be minted. We create manually the
+            // original metadata, following
             // the specifications from the JBMetadataResolver library.
             mintMetadata = JBMetadataResolver.addToMetadata({
                 originalMetadata: additionalPayMetadata,

--- a/test/Test_MetadataGeneration.t.sol
+++ b/test/Test_MetadataGeneration.t.sol
@@ -11,8 +11,8 @@ import {MetadataResolverHelper} from "lib/juice-contracts-v4/test/helpers/Metada
 ///         It uses a mock contract which only returns a metadata following the logic
 ///         of the CroptopPublisher contract during mint. This external contract is used to recreate the same
 contract Test_MetadataGeneration_Unit is Test {
-    
-    /// @notice Create a new metadata from the _additionalPayMetadata and the datahook metadata (containing the tiers to mint).
+    /// @notice Create a new metadata from the _additionalPayMetadata and the datahook metadata (containing the tiers to
+    /// mint).
     /// @dev    Naming follows CroptopPublisher contract.
     function test_metadataBuilding() public {
         MetadataResolverHelper _resolverHelper = new MetadataResolverHelper();
@@ -43,10 +43,10 @@ contract Test_MetadataGeneration_Unit is Test {
 
         // Test: create the new metadata:
         bytes memory mintMetadata = JBMetadataResolver.addToMetadata({
-                originalMetadata: _additionalPayMetadata,
-                idToAdd: datahookId,
-                dataToAdd: abi.encode(true, tierIdsToMint)
-            });
+            originalMetadata: _additionalPayMetadata,
+            idToAdd: datahookId,
+            dataToAdd: abi.encode(true, tierIdsToMint)
+        });
 
         // Add the referal id in the first 32 bytes
         assembly {
@@ -54,7 +54,7 @@ contract Test_MetadataGeneration_Unit is Test {
         }
 
         // Check: both data are present and correct?
-        for(uint256 i = 0; i < _ids.length; i++) {
+        for (uint256 i = 0; i < _ids.length; i++) {
             (bool found, bytes memory targetData) = JBMetadataResolver.getDataFor(_ids[i], mintMetadata);
             assertTrue(found, "metadata not found");
             assertEq(targetData, _datas[i], "metadata not equal");
@@ -66,5 +66,4 @@ contract Test_MetadataGeneration_Unit is Test {
 
         assertEq(uint256(bytes32(mintMetadata)), FEE_PROJECT_ID, "referal id not equal");
     }
-
 }

--- a/test/Test_MetadataGeneration.t.sol
+++ b/test/Test_MetadataGeneration.t.sol
@@ -4,27 +4,37 @@ pragma solidity ^0.8.17;
 import "forge-std/Test.sol";
 import {JBMetadataResolver} from "lib/juice-contracts-v4/src/libraries/JBMetadataResolver.sol";
 
+import {MetadataResolverHelper} from "lib/juice-contracts-v4/test/helpers/MetadataResolverHelper.sol";
+
 /// @notice Quick test to assert the creation of metadata while minting
 /// @dev    This test is not meant to be exhaustive, but to ensure that the metadata is valid.
 ///         It uses a mock contract which only returns a metadata following the logic
-///         of the CroptopPublisher contract during mint.
+///         of the CroptopPublisher contract during mint. This external contract is used to recreate the same
 contract Test_MetadataGeneration_Unit is Test {
-
-    MockPublisher _mockPublisher;
-
-    function setUp() public {
-        _mockPublisher = new MockPublisher();
-    }
     
     /// @notice Create a new metadata from the _additionalPayMetadata and the datahook metadata (containing the tiers to mint).
     /// @dev    Naming follows CroptopPublisher contract.
-    function test_metadataBuilding() public {       
-        // The id's we expect to find in the new metadata:
-        uint256 FEE_PROJECT_ID = 420;
-        bytes4 datahookId = bytes4(bytes20(address(_mockPublisher)));
+    function test_metadataBuilding() public {
+        MetadataResolverHelper _resolverHelper = new MetadataResolverHelper();
 
-        // The data which was added to the metadata:
-        bytes memory _additionalPayMetadata = abi.encodePacked(bytes32(hex'1234567890'), bytes32(hex'deadbeef'));
+        // The intial metadata passed to the terminal
+        bytes4[] memory _ids = new bytes4[](10);
+        bytes[] memory _datas = new bytes[](10);
+
+        for (uint256 _i; _i < _ids.length; _i++) {
+            _ids[_i] = bytes4(uint32(_i + 1 * 1000));
+            _datas[_i] = abi.encode(
+                bytes1(uint8(_i + 1)), uint32(69), bytes2(uint16(_i + 69)), bytes32(uint256(type(uint256).max))
+            );
+        }
+
+        bytes memory _additionalPayMetadata = _resolverHelper.createMetadata(_ids, _datas);
+
+        // The referal to include in the first 32 bytes of the metadata
+        uint256 FEE_PROJECT_ID = 420;
+
+        // The additional metadata to include
+        bytes4 datahookId = bytes4(bytes20(address(0xdeadbeef)));
         uint256[] memory tierIdsToMint = new uint256[](9);
 
         for (uint256 i = 0; i < 9; i++) {
@@ -32,45 +42,29 @@ contract Test_MetadataGeneration_Unit is Test {
         }
 
         // Test: create the new metadata:
-        bytes memory _returnedMetadata = _mockPublisher.mintFrom(FEE_PROJECT_ID, _additionalPayMetadata);
+        bytes memory mintMetadata = JBMetadataResolver.addToMetadata({
+                originalMetadata: _additionalPayMetadata,
+                idToAdd: datahookId,
+                dataToAdd: abi.encode(true, tierIdsToMint)
+            });
 
-        // Check: both data are present and correct?
-        (bool found, bytes memory targetData) = JBMetadataResolver.getDataFor(bytes4(uint32(FEE_PROJECT_ID)), _returnedMetadata);
-        assertTrue(found, "_additionalPayMetadata not found");
-        assertEq(targetData, _additionalPayMetadata, "_additionalPayMetadata not equal");
-
-        (found, targetData) = JBMetadataResolver.getDataFor(datahookId, _returnedMetadata);
-        assertTrue(found, "datahook metadata not found");
-        assertEq(targetData, abi.encode(true, tierIdsToMint), "datahook not equal");
-    }
-
-}
-
-/// @notice Mock contract to return a metadata following the logic of the CroptopPublisher contract during mint.
-contract MockPublisher {
-    function mintFrom(
-        uint256 _feeProjectId,
-        bytes calldata additionalPayMetadata
-    )
-        external
-        payable
-        returns (bytes memory)
-    {   
-        // mock data (same naming as CroptopPublisher contract)
-        address dataHook = address(this);
-        uint256[] memory tierIdsToMint = new uint256[](9);
-
-        for (uint256 i = 0; i < 9; i++) {
-            tierIdsToMint[i] = i + 1;
+        // Add the referal id in the first 32 bytes
+        assembly {
+            mstore(add(mintMetadata, 32), FEE_PROJECT_ID)
         }
 
-        // Recreate the metadata, as ln244 of CroptopPublisher contract:
-        bytes memory mintMetadata = JBMetadataResolver.addToMetadata({
-            originalMetadata: abi.encodePacked(bytes32(0), bytes32(abi.encodePacked(uint32(_feeProjectId), uint8(2))), additionalPayMetadata),
-            idToAdd: bytes4(bytes20(dataHook)),
-            dataToAdd: abi.encode(true, tierIdsToMint)
-        });
+        // Check: both data are present and correct?
+        for(uint256 i = 0; i < _ids.length; i++) {
+            (bool found, bytes memory targetData) = JBMetadataResolver.getDataFor(_ids[i], mintMetadata);
+            assertTrue(found, "metadata not found");
+            assertEq(targetData, _datas[i], "metadata not equal");
+        }
 
-        return mintMetadata;
+        (bool found, bytes memory targetData) = JBMetadataResolver.getDataFor(datahookId, mintMetadata);
+        assertTrue(found, "datahook metadata not found");
+        assertEq(targetData, abi.encode(true, tierIdsToMint), "datahook not equal");
+
+        assertEq(uint256(bytes32(mintMetadata)), FEE_PROJECT_ID, "referal id not equal");
     }
+
 }


### PR DESCRIPTION
# Description

Fix previous metadata creation

## Limitations & risks

Maybe more bugs

# Check-list
- [x] Tests are covering the new feature
- [x] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [x] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [x] I have run the test locally (and they pass)
- [x] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:
CroptopPublisher
- Indirectly:
terminal receiving the metadata